### PR TITLE
Resolved unused variable warnings

### DIFF
--- a/lib/prop_initializer/properties.rb
+++ b/lib/prop_initializer/properties.rb
@@ -74,6 +74,7 @@ module PropInitializer::Properties
   def __generate_prop_initializer_methods__(new_property, buffer = +"")
     buffer << "# frozen_string_literal: true\n"
     prop_initializer_properties.generate_initializer(buffer)
+    prop_initializer_properties.generate_properties(buffer)
     prop_initializer_properties.generate_to_h(buffer)
     new_property.generate_writer_method(buffer) if new_property.writer
     new_property.generate_reader_method(buffer) if new_property.reader

--- a/lib/prop_initializer/properties/schema.rb
+++ b/lib/prop_initializer/properties/schema.rb
@@ -50,6 +50,12 @@ class PropInitializer::Properties::Schema
 			"end\n"
 	end
 
+	def generate_properties(buffer = +"")
+		buffer << "def properties\n"
+		buffer << "  self.class.prop_initializer_properties.properties_index\n"
+		buffer << "end\n"
+	end
+
 	def generate_to_h(buffer = +"")
 		buffer << "def to_h\n" << "  {\n"
 
@@ -103,7 +109,6 @@ class PropInitializer::Properties::Schema
 	end
 
 	def generate_initializer_body(buffer = +"")
-		buffer << "  properties = self.class.prop_initializer_properties.properties_index\n"
 		generate_initializer_handle_properties(@sorted_properties, buffer)
 	end
 

--- a/lib/prop_initializer/property.rb
+++ b/lib/prop_initializer/property.rb
@@ -125,8 +125,7 @@ class PropInitializer::Property
 	end
 
 	def generate_initializer_handle_property(buffer = +"")
-		buffer << "  # " << @name.name << "\n" <<
-			"  property = properties[:" << @name.name << "]\n"
+		buffer << "  # " << @name.name << "\n"
 
 		if @kind == :keyword && ruby_keyword?
 			generate_initializer_escape_keyword(buffer)
@@ -156,7 +155,7 @@ class PropInitializer::Property
 	def generate_initializer_coerce_property(buffer = +"")
 		buffer <<
 			escaped_name <<
-			"= property.coerce(" <<
+			"= properties[:" << @name.name << "].coerce(" <<
 			escaped_name <<
 			", context: self)\n"
 	end
@@ -169,7 +168,7 @@ class PropInitializer::Property
 			escaped_name <<
 			"\n    " <<
 			escaped_name <<
-			" = property.default_value\n  end\n"
+			" = properties[:" << @name.name << "].default_value\n  end\n"
 	end
 
 	def generate_initializer_assign_value(buffer = +"")


### PR DESCRIPTION
If you run avo with ruby warnings enabled you will see a lot of `assigned but unused variable - property` warnings. This is happening because the dynamically generated initializer always includes a property local variable even if it's never used.

To fix this I've removed that variable entirely (and accessed the values we need directly from properties). This is the only place that the properties variable was accessed so I've turned that into a method instead (it was too complex to access this directly every time it's needed).

Fixes #13